### PR TITLE
Fail chef run if backend returns error in reply.

### DIFF
--- a/libraries/kapacitor_api.rb
+++ b/libraries/kapacitor_api.rb
@@ -7,7 +7,8 @@ module KapacitorCookbook
     def create_task(options, task)
       options[:method] = 'Post'
       options[:endpoint] = '/kapacitor/v1/tasks'
-      _do_request(options, task.to_json)
+      task = _do_request(options, task.to_json)
+      raise StandardError, "task['error']" if task['error'] 
     rescue BackendError
       nil
     end


### PR DESCRIPTION
Before you may had syntax error in you tasks and backend was telling that in his reply
but chef-kapacitor was not checking above-mentioned and showed OK. But really nothing was created.