### PR TITLE
Support for templating kapacitor tasks

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,30 +1,30 @@
 ---
 driver_plugin: vagrant
 driver_config:
-  require_chef_omnibus: 12.4.1
   network:
     - ["forwarded_port", {guest: 8080, host: 8080, auto_correct: true}]
 
 provisioner:
   name: chef_zero
+  product_name: chef
+  product_version: 12.21.26
 
 platforms:
-  - name: ubuntu-14.04
-    driver_config:
-      image_ref: Ubuntu 14.04 Trusty (x86_64)
-      flavor_ref: SSD.30
+  - name: ubuntu-16.04
     run_list:
-      - recipe[apt]
+      - recipe[apt::default]
 
 suites:
 - name: default
   run_list:
-    - 'recipe[influxdb]'
-    - 'recipe[kapacitor-test]'
-    - 'recipe[curl]'
+    - recipe[influxdb]
+    - recipe[kapacitor-test]
+    - recipe[curl]
   attributes:
     kapacitor:
       config:
         hostname: localhost
-      version: '1.4.1'
+      version: '1.5.2'
       release: '1'
+      mem_alert:
+        crit: 90

--- a/Berksfile
+++ b/Berksfile
@@ -3,8 +3,9 @@ source 'https://supermarket.chef.io'
 metadata
 
 group :integration do
-  cookbook 'apt'
+  cookbook 'apt', '~> 6.1'
   cookbook 'influxdb'
+  cookbook 'seven_zip', '~> 2'
 end
 
 group :test do

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is used to list changes made in each version of the kapacitor cookbook.
 
+0.0.8
+-----
+- stampit - New template resource, add possibility of specifying template in task definition
+
 0.0.7
 -----
 - Cyberflow - add ability to update handlers

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -21,8 +21,8 @@ default['kapacitor']['package_options'] = value_for_platform_family(
 )
 
 default['kapacitor']['yum']['baseurl'] = value_for_platform(
-  %w[amazon] => { 'default' => 'https://repos.influxdata.com/rhel/6/$basearch/stable' },
-  %w[centos redhat fedora] => { 'default' => 'https://repos.influxdata.com/rhel/6/$basearch/stable' }
+  %w(amazon) => { 'default' => 'https://repos.influxdata.com/rhel/6/$basearch/stable' },
+  %w(centos redhat fedora) => { 'default' => 'https://repos.influxdata.com/rhel/6/$basearch/stable' }
 )
 default['kapacitor']['yum']['description'] = 'InfluxDB Repository - RHEL $releasever'
 default['kapacitor']['yum']['gpgcheck'] = true
@@ -32,7 +32,7 @@ default['kapacitor']['yum']['action'] = :create
 
 default['kapacitor']['apt']['uri'] = "https://repos.influxdata.com/#{node['platform']}"
 default['kapacitor']['apt']['description'] = 'InfluxDB Repository'
-default['kapacitor']['apt']['components'] = %w[stable]
+default['kapacitor']['apt']['components'] = %w(stable)
 default['kapacitor']['apt']['distribution'] = node['lsb']['codename']
 default['kapacitor']['apt']['action'] = :add
 default['kapacitor']['apt']['key'] = 'https://repos.influxdata.com/influxdb.key'

--- a/libraries/kapacitor_api.rb
+++ b/libraries/kapacitor_api.rb
@@ -8,7 +8,7 @@ module KapacitorCookbook
       options[:method] = 'Post'
       options[:endpoint] = '/kapacitor/v1/tasks'
       task = _do_request(options, task.to_json)
-      raise StandardError, "#{task['error']}" unless task['error'].empty?
+      raise StandardError, task['error'].to_s unless task['error'].empty?
     rescue BackendError
       nil
     end
@@ -19,7 +19,7 @@ module KapacitorCookbook
 
       task = _do_request(options, task.to_json)
 
-      raise StandardError, "#{task['error']}" unless task['error'].empty?
+      raise StandardError, task['error'].to_s unless task['error'].empty?
       task
     end
 
@@ -60,6 +60,42 @@ module KapacitorCookbook
       _do_request(options, enable.to_json)
     end
 
+    def create_template(options, template)
+      options[:method] = 'Post'
+      options[:endpoint] = '/kapacitor/v1/templates'
+      template = _do_request(options, template.to_json)
+      raise StandardError, template['error'].to_s unless template['error'].empty?
+    rescue BackendError
+      nil
+    end
+
+    def update_template(options, template)
+      options[:method] = 'Patch'
+      options[:endpoint] = '/kapacitor/v1/templates/' + template[:id]
+
+      template = _do_request(options, template.to_json)
+
+      raise StandardError, template['error'].to_s unless template['error'].empty?
+      template
+    end
+
+    def get_template(options, template)
+      options[:method] = 'Get'
+      options[:endpoint] = '/kapacitor/v1/templates/' + template[:id]
+
+      template = _do_request(options)
+
+      return if template['error'] == 'no template exists'
+      template
+    end
+
+    def delete_template(options, template)
+      options[:method] = 'Delete'
+      options[:endpoint] = '/kapacitor/v1/templates/' + template[:id]
+
+      _do_request(options, enable.to_json)
+    end
+
     # Fetch the json representation of the handler
     # curl http://localhost:9092/kapacitor/v1preview/alerts/topics/<topic id>/handlers/<handler id>.
     def get_handler(options, topic, handler_id)
@@ -82,7 +118,7 @@ module KapacitorCookbook
 
     def update_handler(options, topic, handler)
       options[:method] = 'Put'
-      options[:endpoint] = '/kapacitor/v1/alerts/topics/' +  topic + '/handlers/' + handler[:id]
+      options[:endpoint] = '/kapacitor/v1/alerts/topics/' + topic + '/handlers/' + handler[:id]
 
       handler = _do_request(options, handler.to_json)
 
@@ -126,7 +162,7 @@ module KapacitorCookbook
       tries = opts.fetch :tries
       exceptions = Array(opts.fetch(:exceptions))
 
-      return if tries.zero?
+      return if tries == 0
 
       begin
         yield

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'vir.khatri@gmail.com'
 license          'Apache-2.0'
 description      'Installs/Configures Influxdata Kapacitor'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.0.7'
+version          '0.0.8'
 
 source_url 'https://github.com/vkhatri/chef-kapacitor' if respond_to?(:source_url)
 issues_url 'https://github.com/vkhatri/chef-kapacitor/issues' if respond_to?(:issues_url)
@@ -14,7 +14,7 @@ chef_version '>= 12' if respond_to?(:chef_version)
 depends 'apt'
 depends 'yum-plugin-versionlock', '>= 0.1.2'
 
-%w[ubuntu centos amazon redhat fedora].each do |os|
+%w(ubuntu centos amazon redhat fedora).each do |os|
   supports os
 end
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -30,7 +30,7 @@ if node['kapacitor']['default_config_influxdb']
       'default' => true,
       'name' => 'localhost',
       'urls' => [
-        'http://localhost:8086'
+        'http://localhost:8086',
       ],
       'username' => '',
       'password' => '',
@@ -39,8 +39,8 @@ if node['kapacitor']['default_config_influxdb']
       'udp-buffer' => 1_000,
       'udp-read-buffer' => 0,
       'subscriptions' => {},
-      'excluded-subscriptions' => {}
-    }
+      'excluded-subscriptions' => {},
+    },
   ]
 end
 
@@ -49,7 +49,7 @@ chef_gem 'toml' do
   version node['kapacitor']['toml_gem_version']
 end
 
-include_recipe 'yum-plugin-versionlock::default' if %w[rhel amazon].include?(node['platform_family'])
+include_recipe 'yum-plugin-versionlock::default' if %w(rhel amazon).include?(node['platform_family'])
 include_recipe 'kapacitor::install'
 include_recipe 'kapacitor::config'
 include_recipe 'kapacitor::service'

--- a/recipes/service.rb
+++ b/recipes/service.rb
@@ -24,7 +24,7 @@ ruby_block 'delay kapacitor service start' do
   not_if { node['kapacitor']['disable_service'] }
 end
 
-service_action = node['kapacitor']['disable_service'] ? %i[disable stop] : %i[enable nothing]
+service_action = node['kapacitor']['disable_service'] ? %i(disable stop) : %i(enable nothing)
 
 service 'kapacitor' do
   supports :status => true, :restart => true

--- a/resources/handler.rb
+++ b/resources/handler.rb
@@ -15,10 +15,10 @@ include KapacitorCookbook::KapacitorApi
 action :create do
   options = {
     host: new_resource.host,
-    port: new_resource.port
+    port: new_resource.port,
   }
   handler_options = {
-    id: new_resource.id
+    id: new_resource.id,
   }
   handler_options.merge!(new_resource.actions[0])
 

--- a/resources/task.rb
+++ b/resources/task.rb
@@ -10,6 +10,7 @@ property :type, String
 property :dbrps, Array
 property :script, String
 property :vars, Hash
+property :template, String
 
 default_action :create
 
@@ -18,14 +19,15 @@ include KapacitorCookbook::KapacitorApi
 action :create do
   options = {
     host: new_resource.host,
-    port: new_resource.port
+    port: new_resource.port,
   }
   task_options = {
     id: new_resource.id,
     type: new_resource.type,
     dbrps: new_resource.dbrps,
     script: new_resource.script,
-    vars: new_resource.vars
+    vars: new_resource.vars,
+    :'template-id' => new_resource.template,
   }
 
   # Find wether task already exists
@@ -47,10 +49,10 @@ end
 action :enable do
   options = {
     host: new_resource.host,
-    port: new_resource.port
+    port: new_resource.port,
   }
   task_options = {
-    id: new_resource.id
+    id: new_resource.id,
   }
 
   # Find wether task already exists
@@ -67,10 +69,10 @@ end
 action :delete do
   options = {
     host: new_resource.host,
-    port: new_resource.port
+    port: new_resource.port,
   }
   task_options = {
-    id: new_resource.id
+    id: new_resource.id,
   }
 
   # Find wether task already exists

--- a/resources/template.rb
+++ b/resources/template.rb
@@ -1,0 +1,59 @@
+# resources/template.rb
+#
+# Resource for Kapacitor
+
+property :id, String, name_property: true
+property :host, String, default: 'localhost'
+property :port, Integer, default: 9092
+property :type, String
+property :script, String
+
+default_action :create
+
+include KapacitorCookbook::KapacitorApi
+
+action :create do
+  options = {
+    host: new_resource.host,
+    port: new_resource.port,
+  }
+  template_options = {
+    id: new_resource.id,
+    type: new_resource.type,
+    script: new_resource.script,
+  }
+
+  # Find wether template already exists
+  template = get_template(options, template_options)
+
+  # If not found let's create it
+  if template.nil?
+    converge_by("Creating template #{new_resource.name}") do
+      create_template(options, template_options)
+    end
+  else
+    converge_by("Update template #{new_resource.name}") do
+      update_template(options, template_options)
+    end
+  end
+end
+
+action :delete do
+  options = {
+    host: new_resource.host,
+    port: new_resource.port,
+  }
+  template_options = {
+    id: new_resource.id,
+  }
+
+  # Find wether template already exists
+  template = get_template(options, template_options)
+
+  # If already exist enable
+  if template
+    converge_by("Delete template #{new_resource.name}") do
+      delete_template(options, template_options)
+    end
+  end
+end

--- a/test/fixtures/cookbooks/kapacitor-test/recipes/default.rb
+++ b/test/fixtures/cookbooks/kapacitor-test/recipes/default.rb
@@ -11,7 +11,7 @@ kapacitor_task 'test' do
   type 'stream'
   dbrps [{ 'db' => 'collectd', 'rp' => 'one_hour' }]
   script "stream\n    // Select just the cpu measurement from our example database.\n    |from()\n        .measurement('cpu_value')\n        .where(lambda: \"type_instance\" == 'idle' AND \"type\" == 'percent')\n    |alert()\n        .crit(lambda: \"value\" \u003c 70)\n        // Whenever we get an alert write it to a file.\n        .log('/tmp/alerts.log')\n        .topic('test')\n"
-  action %i[create enable]
+  action %i(create enable)
 end
 
 # update created task
@@ -21,7 +21,7 @@ kapacitor_task 'test' do
   dbrps [{ 'db' => 'collectd', 'rp' => 'one_hour' }]
   script "stream\n    |from()\n        .measurement('cpu_value')\n        .where(lambda: \"type_instance\" == 'idle' AND \"type\" == 'percent')\n    |alert()\n        .crit(lambda: \"value\" \u003c 70)\n                .log('/tmp/alerts.log')\n"
   rewrite true
-  action %i[create enable]
+  action %i(create enable)
 end
 
 kapacitor_handler 'test_handler' do
@@ -37,4 +37,20 @@ kapacitor_handler 'test_handler' do
   topic 'test'
   actions [{ 'kind' => 'log', 'options' => { 'path' => '/tmp/update_alerts.log' } }]
   action :create
+end
+
+kapacitor_template 'test_template' do
+  id 'mem_alert'
+  type 'stream'
+  script "var crit = 70\nstream\n    |from()\n        .measurement('mem')\n    |alert()\n        .crit(lambda: \"used_percent\" \u003e crit)\n        .log('/tmp/memory_ololert.log')\n        .topic('test')\n"
+  action :create
+end
+
+kapacitor_task 'templated_task' do
+  id 'mem_alert'
+  template 'mem_alert'
+  dbrps [{ 'db' => 'node_stats', 'rp' => 'one_hour' }]
+  vars 'crit' => { 'value' => 79, 'type' => 'int' }
+  rewrite true
+  action %i(create enable)
 end

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -10,6 +10,14 @@ describe command('curl http://127.0.0.1:9092/kapacitor/v1/tasks/cpu_alert') do
   its(:stdout) { should contain('cpu_alert') }
 end
 
-describe command('curl http://127.0.0.1:9092/kapacitor/v1preview/alerts/topics/test/handlers/test_handler') do
+describe command('curl http://127.0.0.1:9092/kapacitor/v1/alerts/topics/test/handlers/test_handler') do
   its(:stdout) { should contain('test_handler') }
+end
+
+describe command('curl http://127.0.0.1:9092/kapacitor/v1/templates/mem_alert') do
+  its(:stdout) { should contain('mem_alert') }
+end
+
+describe command('curl http://127.0.0.1:9092/kapacitor/v1/tasks/mem_alert') do
+  its(:stdout) { should contain('"template-id": "mem_alert"') }
 end


### PR DESCRIPTION
- New `kapacitor_template` resource
- New attribute `template` for `kapacitor_task` resource. When present, `type` and `script` attibutes are omitted by kapacitor API
- Cookstyle fixes